### PR TITLE
Unit Printing Hook for Subclasses & Test

### DIFF
--- a/source/Aconcagua-Core/BaseUnit.class.st
+++ b/source/Aconcagua-Core/BaseUnit.class.st
@@ -92,6 +92,15 @@ BaseUnit >> nothingAmount [
 	^0
 ]
 
+{ #category : #printing }
+BaseUnit >> printMeasure: aMeasure on: aStream [
+	"If you need more flexibility, override in subclasses. E.g. '10 dollars' might want to print as '$10'"
+
+	aMeasure amount printOn: aStream.
+	aStream space.
+	aStream nextPutAll: (aMeasure unit nameFor: self amount) asString
+]
+
 { #category : #accessing }
 BaseUnit >> sign [
 

--- a/source/Aconcagua-Core/Measure.class.st
+++ b/source/Aconcagua-Core/Measure.class.st
@@ -460,9 +460,7 @@ Measure >> positive [
 { #category : #printing }
 Measure >> printOn: aStream [
 
-	amount printOn: aStream.
-	aStream space.
-	aStream nextPutAll: (self unit nameFor: self amount) asString
+	self unit printMeasure: self on: aStream
 ]
 
 { #category : #'arithmetic operations - private' }

--- a/source/Aconcagua-Tests/ArithmeticObjectIntervalStrategyTest.class.st
+++ b/source/Aconcagua-Tests/ArithmeticObjectIntervalStrategyTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ArithmeticObjectIntervalStrategyTest,
 	#superclass : #TestCase,
-	#category : #'Aconcagua-Tests-ArithmeticModel'
+	#category : 'Aconcagua-Tests-ArithmeticModel'
 }
 
 { #category : #test }

--- a/source/Aconcagua-Tests/ArithmeticObjectIntervalTest.class.st
+++ b/source/Aconcagua-Tests/ArithmeticObjectIntervalTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #ArithmeticObjectIntervalTest,
 	#superclass : #TestCase,
-	#category : #'Aconcagua-Tests-ArithmeticModel'
+	#category : 'Aconcagua-Tests-ArithmeticModel'
 }
 
 { #category : #'test accessing' }

--- a/source/Aconcagua-Tests/BaseUnitTest.class.st
+++ b/source/Aconcagua-Tests/BaseUnitTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #BaseUnitTest,
 	#superclass : #TestCase,
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #'test accessing' }
@@ -496,6 +496,16 @@ BaseUnitTest >> testNumerator [
 	unit := BaseUnit nameForOne: 'peso' nameForMany: 'pepe'.
 
 	self assert: unit numerator = unit
+]
+
+{ #category : #'test printing' }
+BaseUnitTest >> testPrintingCustomization [
+
+	| unit measure |
+	
+	unit := DummyDollarUnit named: 'dollar'.
+	measure := Measure amount: 5 unit: unit.
+	self assert: measure printString equals: '$5.00'.
 ]
 
 { #category : #'test accessing' }

--- a/source/Aconcagua-Tests/CircularReadStreamTest.class.st
+++ b/source/Aconcagua-Tests/CircularReadStreamTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'stream',
 		'streamStaringInThirdElement'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }

--- a/source/Aconcagua-Tests/DividedUnitTest.class.st
+++ b/source/Aconcagua-Tests/DividedUnitTest.class.st
@@ -6,7 +6,7 @@ Class {
 		'second',
 		'meterOverSecond'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }

--- a/source/Aconcagua-Tests/DummyDollarUnit.class.st
+++ b/source/Aconcagua-Tests/DummyDollarUnit.class.st
@@ -1,0 +1,12 @@
+Class {
+	#name : #DummyDollarUnit,
+	#superclass : #BaseUnit,
+	#category : #'Aconcagua-Tests-MeasureModel'
+}
+
+{ #category : #printing }
+DummyDollarUnit >> printMeasure: aMeasure on: aStream [
+
+	aStream nextPut: $$.
+	aStream nextPutAll: (aMeasure amount asFloat printPaddedWith: $0 to: 1.2).
+]

--- a/source/Aconcagua-Tests/DummyEvaluation.class.st
+++ b/source/Aconcagua-Tests/DummyEvaluation.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'measure'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #'instance creation' }

--- a/source/Aconcagua-Tests/EvaluationTest.class.st
+++ b/source/Aconcagua-Tests/EvaluationTest.class.st
@@ -8,7 +8,7 @@ Class {
 		'peso',
 		'dollar'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #'test support' }

--- a/source/Aconcagua-Tests/InfinityClassTest.class.st
+++ b/source/Aconcagua-Tests/InfinityClassTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'meter',
 		'second'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }

--- a/source/Aconcagua-Tests/IntervalAwareMagnitudeTest.class.st
+++ b/source/Aconcagua-Tests/IntervalAwareMagnitudeTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #IntervalAwareMagnitudeTest,
 	#superclass : #TestCase,
-	#category : #'Aconcagua-Tests-ArithmeticModel'
+	#category : 'Aconcagua-Tests-ArithmeticModel'
 }
 
 { #category : #test }

--- a/source/Aconcagua-Tests/MeasureBagTest.class.st
+++ b/source/Aconcagua-Tests/MeasureBagTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'units'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #resources }

--- a/source/Aconcagua-Tests/MeasureTest.class.st
+++ b/source/Aconcagua-Tests/MeasureTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'units'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #resources }

--- a/source/Aconcagua-Tests/MinusInfinityClassTest.class.st
+++ b/source/Aconcagua-Tests/MinusInfinityClassTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'meter',
 		'second'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }

--- a/source/Aconcagua-Tests/MultipliedUnitTest.class.st
+++ b/source/Aconcagua-Tests/MultipliedUnitTest.class.st
@@ -6,7 +6,7 @@ Class {
 		'second',
 		'meterBySecond'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }

--- a/source/Aconcagua-Tests/NotProportionalDerivedUnitTest.class.st
+++ b/source/Aconcagua-Tests/NotProportionalDerivedUnitTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'kelvin'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }

--- a/source/Aconcagua-Tests/NullUnitTest.class.st
+++ b/source/Aconcagua-Tests/NullUnitTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'nullUnit'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }

--- a/source/Aconcagua-Tests/NumberMeasureProtocolTest.class.st
+++ b/source/Aconcagua-Tests/NumberMeasureProtocolTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #NumberMeasureProtocolTest,
 	#superclass : #TestCase,
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #'test accessing' }

--- a/source/Aconcagua-Tests/NumberToArithmeticObjectAdapterTest.class.st
+++ b/source/Aconcagua-Tests/NumberToArithmeticObjectAdapterTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #NumberToArithmeticObjectAdapterTest,
 	#superclass : #TestCase,
-	#category : #'Aconcagua-Tests-ArithmeticModel'
+	#category : 'Aconcagua-Tests-ArithmeticModel'
 }
 
 { #category : #test }

--- a/source/Aconcagua-Tests/ProportionalDerivedUnitTest.class.st
+++ b/source/Aconcagua-Tests/ProportionalDerivedUnitTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'peso',
 		'centavo'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }

--- a/source/Aconcagua-Tests/TestIntervalAwareMagnitude.class.st
+++ b/source/Aconcagua-Tests/TestIntervalAwareMagnitude.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'number'
 	],
-	#category : #'Aconcagua-Tests-ArithmeticModel'
+	#category : 'Aconcagua-Tests-ArithmeticModel'
 }
 
 { #category : #'instance creation' }

--- a/source/Aconcagua-Tests/TestIntervalStrategy.class.st
+++ b/source/Aconcagua-Tests/TestIntervalStrategy.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #TestIntervalStrategy,
 	#superclass : #IntervalStrategy,
-	#category : #'Aconcagua-Tests-ArithmeticModel'
+	#category : 'Aconcagua-Tests-ArithmeticModel'
 }
 
 { #category : #enumerating }

--- a/source/Aconcagua-Tests/UndefinedArithmeticObjectValueExceptionTest.class.st
+++ b/source/Aconcagua-Tests/UndefinedArithmeticObjectValueExceptionTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #UndefinedArithmeticObjectValueExceptionTest,
 	#superclass : #TestCase,
-	#category : #'Aconcagua-Tests-ArithmeticModel'
+	#category : 'Aconcagua-Tests-ArithmeticModel'
 }
 
 { #category : #test }

--- a/source/Aconcagua-Tests/UnitsTestResource.class.st
+++ b/source/Aconcagua-Tests/UnitsTestResource.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'units'
 	],
-	#category : #'Aconcagua-Tests-MeasureModel'
+	#category : 'Aconcagua-Tests-MeasureModel'
 }
 
 { #category : #initialization }


### PR DESCRIPTION
Gives more flexibility where the domain needs it e.g.
```smalltalk
| unit measure |
	
unit := DummyDollarUnit named: 'dollar'.
measure := Measure amount: 5 unit: unit.
self assert: measure printString equals: '$5.00'.
```