### PR TITLE
Rename UnitNames to UnitNomenclature

### DIFF
--- a/source/Aconcagua-Quantitative-Analysis/BaseUnitOfMeasure.class.st
+++ b/source/Aconcagua-Quantitative-Analysis/BaseUnitOfMeasure.class.st
@@ -20,7 +20,7 @@ BaseUnitOfMeasure class >> measuring: dimension singularNamed: singularName plur
 
   ^ self new
       initializeMeasuring: dimension
-      named: ( UnitNames singular: singularName plural: pluralName symbol: symbol )
+      named: ( UnitNomenclature singular: singularName plural: pluralName symbol: symbol )
 ]
 
 { #category : 'converting' }

--- a/source/Aconcagua-Quantitative-Analysis/DerivedUnit.class.st
+++ b/source/Aconcagua-Quantitative-Analysis/DerivedUnit.class.st
@@ -81,7 +81,7 @@ DerivedUnit >> aliasedBy: singularName plural: pluralName symbol: symbol [
   ^ self class
       composedOfAll: exponentsByUnit
       nameOptional:
-      ( Optional containing: ( UnitNames singular: singularName plural: pluralName symbol: symbol ) )
+      ( Optional containing: ( UnitNomenclature singular: singularName plural: pluralName symbol: symbol ) )
 ]
 
 { #category : 'converting' }

--- a/source/Aconcagua-Quantitative-Analysis/MultipleUnitOfMeasure.class.st
+++ b/source/Aconcagua-Quantitative-Analysis/MultipleUnitOfMeasure.class.st
@@ -44,7 +44,7 @@ MultipleUnitOfMeasure class >> basedOn: baseUnit singularNamed: singularName plu
 
   ^ self new
       initializeBasedOn: baseUnit
-      named: ( UnitNames singular: singularName plural: pluralName symbol: symbol )
+      named: ( UnitNomenclature singular: singularName plural: pluralName symbol: symbol )
       factor: factor
 ]
 

--- a/source/Aconcagua-Quantitative-Analysis/UnitNomenclature.class.st
+++ b/source/Aconcagua-Quantitative-Analysis/UnitNomenclature.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'UnitNames',
+	#name : 'UnitNomenclature',
 	#superclass : 'Object',
 	#instVars : [
 		'singular',
@@ -11,13 +11,13 @@ Class {
 }
 
 { #category : 'instance creation' }
-UnitNames class >> singular: aSingularName plural: aPluralName symbol: aSymbol [
+UnitNomenclature class >> singular: aSingularName plural: aPluralName symbol: aSymbol [
 
   ^ self new initializeSingular: aSingularName plural: aPluralName symbol: aSymbol
 ]
 
 { #category : 'initialization' }
-UnitNames >> initializeSingular: aSingularName plural: aPluralName symbol: aSymbol [
+UnitNomenclature >> initializeSingular: aSingularName plural: aPluralName symbol: aSymbol [
 
   singular := aSingularName.
   plural := aPluralName.
@@ -25,19 +25,19 @@ UnitNames >> initializeSingular: aSingularName plural: aPluralName symbol: aSymb
 ]
 
 { #category : 'accessing' }
-UnitNames >> plural [
+UnitNomenclature >> plural [
 
   ^ plural localized
 ]
 
 { #category : 'accessing' }
-UnitNames >> singular [
+UnitNomenclature >> singular [
 
   ^ singular localized
 ]
 
 { #category : 'accessing' }
-UnitNames >> symbol [
+UnitNomenclature >> symbol [
 
   ^ symbol
 ]


### PR DESCRIPTION
This class is for internal use so it doesn't break any compatibility